### PR TITLE
Improve mobile usability of word search grid and word list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Search, Plus } from 'lucide-react';
+import { Search, Plus, List, X } from 'lucide-react';
 import { supabase, type WordSearchGame } from './lib/supabase';
 import { generateWordSearch, type WordPlacement } from './utils/wordSearchGenerator';
 import { getRandomWords } from './utils/norwegianWords';
@@ -16,6 +16,7 @@ function App() {
   const [score, setScore] = useState(0);
   const [timeElapsed, setTimeElapsed] = useState(0);
   const [isGameActive, setIsGameActive] = useState(false);
+  const [isWordListOpen, setWordListOpen] = useState(false);
 
   useEffect(() => {
     loadGames();
@@ -116,6 +117,7 @@ function App() {
     setScore(0);
     setTimeElapsed(0);
     setIsGameActive(false);
+    setWordListOpen(false);
   };
 
   const handleNewGame = () => {
@@ -124,6 +126,7 @@ function App() {
     setScore(0);
     setTimeElapsed(0);
     setIsGameActive(false);
+    setWordListOpen(false);
   };
 
   if (loading) {
@@ -205,22 +208,55 @@ function App() {
             )}
 
             <div className="flex flex-col lg:flex-row gap-6 items-start justify-center">
+              <button
+                type="button"
+                onClick={() => setWordListOpen(true)}
+                className="lg:hidden self-center bg-blue-600 text-white px-4 py-2 rounded-lg shadow-md flex items-center gap-2"
+              >
+                <List size={18} />
+                Vis ordliste
+              </button>
+
               <WordSearchGrid
                 grid={currentGame.grid_data}
                 words={currentGame.words}
                 onWordFound={handleWordFound}
               />
 
-              <div className="lg:w-80">
+              <div className="lg:w-80 hidden lg:block">
                 <WordList
                   words={currentGame.words.map((w: WordPlacement) => w.word)}
                   foundWords={foundWords}
+                  variant="panel"
                 />
               </div>
             </div>
           </div>
         )}
       </div>
+
+      {currentGame && isWordListOpen && (
+        <div className="lg:hidden fixed inset-0 z-50 flex items-end justify-center bg-black/40 px-4 pb-6">
+          <div className="w-full max-w-md bg-white rounded-2xl shadow-2xl p-4 max-h-[70vh] overflow-y-auto">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-lg font-semibold text-gray-800">Ord å finne</h3>
+              <button
+                type="button"
+                onClick={() => setWordListOpen(false)}
+                className="p-2 rounded-full bg-gray-100 text-gray-600 hover:bg-gray-200"
+                aria-label="Lukk ordliste"
+              >
+                <X size={18} />
+              </button>
+            </div>
+            <WordList
+              words={currentGame.words.map((w: WordPlacement) => w.word)}
+              foundWords={foundWords}
+              variant="drawer"
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/WordList.tsx
+++ b/src/components/WordList.tsx
@@ -3,9 +3,38 @@ import { Check } from 'lucide-react';
 type Props = {
   words: string[];
   foundWords: Set<string>;
+  variant?: 'panel' | 'drawer';
 };
 
-export default function WordList({ words, foundWords }: Props) {
+export default function WordList({ words, foundWords, variant = 'panel' }: Props) {
+  if (variant === 'drawer') {
+    return (
+      <div className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          {words.map((word) => {
+            const isFound = foundWords.has(word);
+            return (
+              <span
+                key={word}
+                className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                  isFound
+                    ? 'bg-green-100 text-green-800 line-through'
+                    : 'bg-gray-100 text-gray-700'
+                }`}
+              >
+                {isFound && <Check size={16} className="text-green-600" />}
+                {word}
+              </span>
+            );
+          })}
+        </div>
+        <p className="text-sm text-gray-600">
+          Funnet: {foundWords.size} / {words.length}
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white rounded-lg shadow-lg p-6">
       <h3 className="text-xl font-bold text-gray-800 mb-4">Ord å finne</h3>

--- a/src/components/WordSearchGrid.tsx
+++ b/src/components/WordSearchGrid.tsx
@@ -21,6 +21,7 @@ export default function WordSearchGrid({ grid, words, onWordFound }: Props) {
   const [foundWords, setFoundWords] = useState<Set<string>>(new Set());
   const [isSelecting, setIsSelecting] = useState(false);
   const gridRef = useRef<HTMLDivElement>(null);
+  const gridSize = grid.length;
 
   const isCellSelected = (row: number, col: number) => {
     return selectedCells.some(cell => cell.row === row && cell.col === col);
@@ -135,13 +136,22 @@ export default function WordSearchGrid({ grid, words, onWordFound }: Props) {
     }
   };
 
-  const handleTouchEnd = (e: React.TouchEvent) => {
-    e.preventDefault();
+  const finalizeSelection = () => {
     if (selectedCells.length > 0) {
       checkForWord();
     }
     setIsSelecting(false);
     setSelectedCells([]);
+  };
+
+  const handleTouchEnd = (e: React.TouchEvent) => {
+    e.preventDefault();
+    finalizeSelection();
+  };
+
+  const handleTouchCancel = (e: React.TouchEvent) => {
+    e.preventDefault();
+    finalizeSelection();
   };
 
   const checkForWord = () => {
@@ -165,42 +175,45 @@ export default function WordSearchGrid({ grid, words, onWordFound }: Props) {
   return (
     <div
       ref={gridRef}
-      className="inline-block select-none touch-none"
+      className="inline-block select-none touch-none w-full"
+      style={{ maxWidth: 'min(90vw, 28rem)' }}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
       onTouchMove={handleTouchMove}
       onTouchEnd={handleTouchEnd}
+      onTouchCancel={handleTouchCancel}
     >
-      <div className="grid gap-1 bg-white p-4 rounded-lg shadow-lg">
-        {grid.map((row, rowIndex) => (
-          <div key={rowIndex} className="flex gap-1">
-            {row.map((letter, colIndex) => {
-              const selected = isCellSelected(rowIndex, colIndex);
-              const found = isCellInFoundWord(rowIndex, colIndex);
+      <div
+        className="grid gap-1 bg-white p-4 rounded-lg shadow-lg"
+        style={{ gridTemplateColumns: `repeat(${gridSize}, minmax(0, 1fr))` }}
+      >
+        {grid.map((row, rowIndex) =>
+          row.map((letter, colIndex) => {
+            const selected = isCellSelected(rowIndex, colIndex);
+            const found = isCellInFoundWord(rowIndex, colIndex);
 
-              return (
-                <div
-                  key={`${rowIndex}-${colIndex}`}
-                  data-cell
-                  data-row={rowIndex}
-                  data-col={colIndex}
-                  className={`
-                    w-10 h-10 md:w-8 md:h-8 flex items-center justify-center
-                    font-semibold text-sm cursor-pointer
-                    rounded transition-colors
-                    ${found ? 'bg-green-200 text-green-800' : 'bg-gray-50 hover:bg-gray-100'}
-                    ${selected ? 'bg-blue-300 text-blue-900' : ''}
-                  `}
-                  onMouseDown={() => handleMouseDown(rowIndex, colIndex)}
-                  onMouseEnter={() => handleMouseEnter(rowIndex, colIndex)}
-                  onTouchStart={(e) => handleTouchStart(e, rowIndex, colIndex)}
-                >
-                  {letter}
-                </div>
-              );
-            })}
-          </div>
-        ))}
+            return (
+              <div
+                key={`${rowIndex}-${colIndex}`}
+                data-cell
+                data-row={rowIndex}
+                data-col={colIndex}
+                className={`
+                  flex items-center justify-center
+                  font-semibold text-xs sm:text-sm cursor-pointer
+                  rounded transition-colors w-full aspect-square
+                  ${found ? 'bg-green-200 text-green-800' : 'bg-gray-50 hover:bg-gray-100'}
+                  ${selected ? 'bg-blue-300 text-blue-900' : ''}
+                `}
+                onMouseDown={() => handleMouseDown(rowIndex, colIndex)}
+                onMouseEnter={() => handleMouseEnter(rowIndex, colIndex)}
+                onTouchStart={(e) => handleTouchStart(e, rowIndex, colIndex)}
+              >
+                {letter}
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- refactor the word search grid to use a responsive CSS grid with flexible cell sizing and touch-cancel cleanup
- add a mobile drawer presentation of the word list with a toggle button while keeping the desktop panel layout
- support multiple display variants in the word list component for reuse across screen sizes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2be73e944832a860f52ee53486156